### PR TITLE
Integrate first basic api

### DIFF
--- a/ui/components/HelloApp.vue
+++ b/ui/components/HelloApp.vue
@@ -1,18 +1,33 @@
 <template>
-  <div class="uk-flex uk-flex-center uk-flex-middle">
+  <div>
     <h1>
-      Hello {{ name }}
+      Hello
     </h1>
+
+    <form v-on:submit.prevent="submitHello" action="#" method="post">
+      <input v-model="name" placeholder="What is your name?">
+
+      <button type="submit">
+        Submit
+      </button>
+    </form>
+
+    <p v-if="message">
+      {{ message }}
+    </p>
   </div>
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
+import { mapGetters, mapActions } from 'vuex'
 
 export default {
   name: 'HelloApp',
+  methods: {
+    ...mapActions('Hello', ['submitHello'])
+  },
   computed: {
-    ...mapGetters('Hello', ['name'])
+    ...mapGetters('Hello', ['name', 'message'])
   }
 }
 </script>

--- a/ui/store.js
+++ b/ui/store.js
@@ -1,15 +1,52 @@
 const namespaced = true
 
 const state = {
-  name: 'World'
+  name: 'World',
+  message: ''
 }
 
 const getters = {
-  name: state => state.name
+  name: state => state.name,
+  message: state => state.message
+}
+
+const actions = {
+  submitHello (context, value) {
+    fetch(`http://localhost:8380/api/hello`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        'name': this.state.Hello.name
+      })
+    })
+      .then(response => {
+        if (response.ok) {
+          response.json()
+            .then(json => {
+              context.commit('MESSAGE', json.message)
+            })
+        } else {
+          console.error('response', response)
+        }
+      })
+      .catch((error) => {
+        console.error('catch', error)
+      })
+  }
+}
+
+const mutations = {
+  MESSAGE (state, payload) {
+    state.message = payload
+  }
 }
 
 export default {
   namespaced,
   state,
-  getters
+  getters,
+  actions,
+  mutations
 }


### PR DESCRIPTION
This PR adds the first really really really basic API. You can post a payload like `{"name": "Thomas"}` to `/api/hello`, and it will respond with `{"message": "Hello Thomas"}`, nothing more.

On the frontend part are still some issues which hopefully could be resolved by @LukasHirt:

* Within the store the API endpoint is hard-coded to `http://localhost:8380/api/hello`, how should we configure that?
* The store is using `this.state.Hello.name` within the fetch call to get the name typed into the input, that doesn't seem to be the right value.
* The naming should be defined by some kind of standard.
* The frontend is simply looking ugly, a good start to give it some styling.