### PR TITLE
Fix the page structure

### DIFF
--- a/docs/content/building.md
+++ b/docs/content/building.md
@@ -14,7 +14,7 @@ cd ocis-hello
 
 All required tool besides Go itself and make are bundled or getting automatically installed within the `GOPATH`. All commands to build this project are part of our `Makefile` and respectively our `package.json`.
 
-## Frontend
+### Frontend
 
 {{< highlight txt >}}
 yarn install
@@ -23,7 +23,7 @@ yarn build
 
 The above commands will install the required build dependencies and build the whole frontend bundle. This bundle will we embeded into the binary later on.
 
-## Backend
+### Backend
 
 {{< highlight txt >}}
 make generate

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -5,27 +5,27 @@ anchor: "getting-started"
 weight: 20
 ---
 
-## Installation
+### Installation
 
 So far we are offering two different variants for the installation. You can choose between [Docker](docker) or pre-built binaries which are stored on our download mirrors and GitHub releases. Maybe we will also provide system packages for the major distributions later if we see the need for it.
 
-### Docker
+#### Docker
 
 TBD
 
-### Binaries
+#### Binaries
 
 TBD
 
-## Configuration
+### Configuration
 
 We provide overall three different variants of configuration. The variant based on environment variables and commandline flags are split up into global values and command-specific values.
 
-### Envrionment variables
+#### Envrionment variables
 
 If you prefer to configure the service with environment variables you can see the available variables below.
 
-#### Global
+##### Global
 
 HELLO_LOG_LEVEL
 : Set logging level, defaults to `info`
@@ -36,7 +36,7 @@ HELLO_LOG_COLOR
 HELLO_LOG_PRETTY
 : Enable pretty logging, defaults to `true`
 
-#### Server
+##### Server
 
 HELLO_DEBUG_ADDR
 : Address to bind debug server, defaults to `0.0.0.0:8390`
@@ -56,16 +56,16 @@ HELLO_HTTP_ROOT
 HELLO_ASSET_PATH
 : Path to custom assets, empty default value
 
-#### Health
+##### Health
 
 HELLO_DEBUG_ADDR
 : Address to debug endpoint, defaults to `0.0.0.0:8390`
 
-### Commandline flags
+#### Commandline flags
 
 If you prefer to configure the service with commandline flags you can see the available variables below.
 
-#### Global
+##### Global
 
 --log-level
 : Set logging level, defaults to `info`
@@ -76,7 +76,7 @@ If you prefer to configure the service with commandline flags you can see the av
 --log-pretty
 : Enable pretty logging, defaults to `true`
 
-#### Server
+##### Server
 
 --debug-addr
 : Address to bind debug server, defaults to `0.0.0.0:8390`
@@ -96,20 +96,20 @@ If you prefer to configure the service with commandline flags you can see the av
 --asset-path
 : Path to custom assets, empty default value
 
-#### Health
+##### Health
 
 --debug-addr
 : Address to debug endpoint, defaults to `0.0.0.0:8390`
 
-### Configuration file
+#### Configuration file
 
 So far we support the file formats `JSON` and `YAML`, if you want to get a full example configuration just take a look at [our repository](repo), there you can always see the latest configuration format. These example configurations include all available options and the default values. The configuration file will be automatically loaded if it's placed at `/etc/ocis/hello.yml`, `${HOME}/.ocis/hello.yml` or `$(pwd)/config/hello.yml`.
 
-## Usage
+### Usage
 
 The program provides a few sub-commands on execution. The available configuration methods have already been mentioned above. Generally you can always see a formated help output if you execute the binary via `ocis-hello --help`.
 
-### Server
+#### Server
 
 The server command is used to start the http and debug server on two addresses within a single process. The http server is serving the general webservice while the debug server is used for health check, readiness check and to server the metrics mentioned below. For further help please execute:
 
@@ -117,7 +117,7 @@ The server command is used to start the http and debug server on two addresses w
 ocis-hello server --help
 {{< / highlight >}}
 
-### Health
+#### Health
 
 The health command is used to execute a health check, if the exit code equals zero the service should be up and running, if the exist code is greater than zero the service is not in a healthy state. Generally this command is used within our Docker containers, it could also be used within Kubernetes.
 
@@ -125,7 +125,7 @@ The health command is used to execute a health check, if the exit code equals ze
 ocis-hello health --help
 {{< / highlight >}}
 
-## Metrics
+### Metrics
 
 This service provides some [Prometheus](prom) metrics through the debug endpoint, you can optionally secure the metrics endpoint by some random token, which got to be configured through one of the flag `--debug-token` or the environment variable `HELLO_DEBUG_TOKEN` mentioned above. By default the metrics endpoint is bound to `http://0.0.0.0:8390/metrics`.
 

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -38,7 +38,7 @@
 
 		{{ range .Data.Pages.ByWeight }}
 			<section id="{{ .Params.anchor }}">
-				<h1>
+				<h2>
 					<a href="#{{ .Params.anchor }}">
 						{{ .Title }}
 					</a>
@@ -48,7 +48,7 @@
 							Back to Top
 						</a>
 					</small>
-				</h1>
+				</h2>
 
 				{{ .Content | markdownify }}
 			</section>


### PR DESCRIPTION
This change corrects a bug in the templates that renders the headers for each page as an h1. This would be semantically correct if each page were rendered in isolation. However, since they're rendered together as one page, then the semantic structure is broken.

