### PR TITLE
Downgrade Golang to 1.12

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -45,7 +45,7 @@ def testing(ctx):
       },
       {
         'name': 'generate',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'make generate',
@@ -59,7 +59,7 @@ def testing(ctx):
       },
       {
         'name': 'vet',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'make vet',
@@ -73,7 +73,7 @@ def testing(ctx):
       },
       {
         'name': 'staticcheck',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'make staticcheck',
@@ -87,7 +87,7 @@ def testing(ctx):
       },
       {
         'name': 'lint',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'make lint',
@@ -101,7 +101,7 @@ def testing(ctx):
       },
       {
         'name': 'build',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'make build',
@@ -115,7 +115,7 @@ def testing(ctx):
       },
       {
         'name': 'test',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'make test',
@@ -174,7 +174,7 @@ def docker(ctx, arch):
       },
       {
         'name': 'generate',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'make generate',
@@ -188,7 +188,7 @@ def docker(ctx, arch):
       },
       {
         'name': 'build',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'make build',
@@ -321,7 +321,7 @@ def binary(ctx, name):
       },
       {
         'name': 'generate',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'make generate',
@@ -335,7 +335,7 @@ def binary(ctx, name):
       },
       {
         'name': 'build',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'make release-%s' % (name),
@@ -349,7 +349,7 @@ def binary(ctx, name):
       },
       {
         'name': 'finish',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'make release-finish',
@@ -504,7 +504,7 @@ def changelog(ctx):
       },
       {
         'name': 'generate',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'make changelog',
@@ -512,7 +512,7 @@ def changelog(ctx):
       },
       {
         'name': 'output',
-        'image': 'webhippie/golang:1.13',
+        'image': 'webhippie/golang:1.12',
         'pull': 'always',
         'commands': [
           'cat CHANGELOG.md',

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/owncloud/ocis-hello
 
-go 1.13
+go 1.12
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.0


### PR DESCRIPTION
First of all we mention that this project can be built with Go 1.12, so
we should make sure this is really the case. On the other side our
projects provide binaries which are also cross-compiled for arm64,
currently 1.13 does not build the arm64 binaries, so let's use a Go
version that is known to do that correctly.

