### PR TITLE
Inject flags on initialization

### DIFF
--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -132,12 +132,15 @@ func Server(cfg *config.Config) cli.Command {
 
 			defer cancel()
 
+			// Flags have to be injected all the way down to the go-micro service
 			{
 				server, err := http.Server(
 					http.Logger(logger),
 					http.Context(ctx),
 					http.Config(cfg),
 					http.Metrics(metrics),
+					http.Flags(flagset.RootWithConfig(cfg)),
+					http.Flags(flagset.ServerWithConfig(cfg)),
 				)
 
 				if err != nil {
@@ -166,6 +169,8 @@ func Server(cfg *config.Config) cli.Command {
 					grpc.Context(ctx),
 					grpc.Config(cfg),
 					grpc.Metrics(metrics),
+					grpc.Flags(flagset.RootWithConfig(cfg)),
+					grpc.Flags(flagset.ServerWithConfig(cfg)),
 				)
 
 				if err != nil {

--- a/pkg/server/grpc/option.go
+++ b/pkg/server/grpc/option.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 
+	"github.com/micro/cli"
 	"github.com/owncloud/ocis-hello/pkg/config"
 	"github.com/owncloud/ocis-hello/pkg/metrics"
 	"github.com/owncloud/ocis-pkg/log"
@@ -17,6 +18,7 @@ type Options struct {
 	Context context.Context
 	Config  *config.Config
 	Metrics *metrics.Metrics
+	Flags   []cli.Flag
 }
 
 // newOptions initializes the available default options.
@@ -55,5 +57,12 @@ func Config(val *config.Config) Option {
 func Metrics(val *metrics.Metrics) Option {
 	return func(o *Options) {
 		o.Metrics = val
+	}
+}
+
+// Flags provides a function to set the flags option.
+func Flags(val []cli.Flag) Option {
+	return func(o *Options) {
+		o.Flags = append(o.Flags, val...)
 	}
 }

--- a/pkg/server/grpc/server.go
+++ b/pkg/server/grpc/server.go
@@ -1,10 +1,8 @@
 package grpc
 
 import (
-	"github.com/owncloud/ocis-hello/pkg/config"
-	"github.com/owncloud/ocis-hello/pkg/flagset"
 	"github.com/owncloud/ocis-hello/pkg/proto/v0"
-	"github.com/owncloud/ocis-hello/pkg/service/v0"
+	svc "github.com/owncloud/ocis-hello/pkg/service/v0"
 	"github.com/owncloud/ocis-hello/pkg/version"
 	"github.com/owncloud/ocis-pkg/service/grpc"
 )
@@ -20,8 +18,7 @@ func Server(opts ...Option) (grpc.Service, error) {
 		grpc.Version(version.String),
 		grpc.Address(options.Config.GRPC.Addr),
 		grpc.Context(options.Context),
-		grpc.Flags(flagset.RootWithConfig(config.New())...),
-		grpc.Flags(flagset.ServerWithConfig(config.New())...),
+		grpc.Flags(options.Flags...),
 	)
 
 	var hello proto.HelloHandler

--- a/pkg/server/http/option.go
+++ b/pkg/server/http/option.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 
+	"github.com/micro/cli"
 	"github.com/owncloud/ocis-hello/pkg/config"
 	"github.com/owncloud/ocis-hello/pkg/metrics"
 	"github.com/owncloud/ocis-pkg/log"
@@ -17,6 +18,7 @@ type Options struct {
 	Context context.Context
 	Config  *config.Config
 	Metrics *metrics.Metrics
+	Flags   []cli.Flag
 }
 
 // newOptions initializes the available default options.
@@ -55,5 +57,12 @@ func Config(val *config.Config) Option {
 func Metrics(val *metrics.Metrics) Option {
 	return func(o *Options) {
 		o.Metrics = val
+	}
+}
+
+// Flags provides a function to set the flags option.
+func Flags(val []cli.Flag) Option {
+	return func(o *Options) {
+		o.Flags = append(o.Flags, val...)
 	}
 }

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -3,10 +3,8 @@ package http
 import (
 	"github.com/go-chi/chi"
 	"github.com/owncloud/ocis-hello/pkg/assets"
-	"github.com/owncloud/ocis-hello/pkg/config"
-	"github.com/owncloud/ocis-hello/pkg/flagset"
 	"github.com/owncloud/ocis-hello/pkg/proto/v0"
-	"github.com/owncloud/ocis-hello/pkg/service/v0"
+	svc "github.com/owncloud/ocis-hello/pkg/service/v0"
 	"github.com/owncloud/ocis-hello/pkg/version"
 	"github.com/owncloud/ocis-pkg/middleware"
 	"github.com/owncloud/ocis-pkg/service/http"
@@ -23,8 +21,7 @@ func Server(opts ...Option) (http.Service, error) {
 		http.Version(version.String),
 		http.Address(options.Config.HTTP.Addr),
 		http.Context(options.Context),
-		http.Flags(flagset.RootWithConfig(config.New())...),
-		http.Flags(flagset.ServerWithConfig(config.New())...),
+		http.Flags(options.Flags...),
 	)
 
 	hello := svc.NewService()


### PR DESCRIPTION
As long as the initialization logic is specific to the http / grpc service, every extension needs to include this patch.