### PR TITLE
Namespace Flags

### DIFF
--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -39,6 +39,7 @@ func Server(cfg *config.Config) cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			logger := NewLogger(cfg)
+			namespace := c.String("namespace")
 
 			if cfg.Tracing.Enabled {
 				switch t := cfg.Tracing.Type; t {
@@ -136,6 +137,7 @@ func Server(cfg *config.Config) cli.Command {
 			{
 				server, err := http.Server(
 					http.Logger(logger),
+					http.Namespace(namespace),
 					http.Context(ctx),
 					http.Config(cfg),
 					http.Metrics(metrics),
@@ -166,6 +168,7 @@ func Server(cfg *config.Config) cli.Command {
 			{
 				server, err := grpc.Server(
 					grpc.Logger(logger),
+					grpc.Namespace(namespace),
 					grpc.Context(ctx),
 					grpc.Config(cfg),
 					grpc.Metrics(metrics),

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -39,7 +39,8 @@ func Server(cfg *config.Config) cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			logger := NewLogger(cfg)
-			namespace := c.String("namespace")
+			httpNamespace := c.String("http-namespace")
+			grpcNamespace := c.String("grpc-namespace")
 
 			if cfg.Tracing.Enabled {
 				switch t := cfg.Tracing.Type; t {
@@ -137,7 +138,7 @@ func Server(cfg *config.Config) cli.Command {
 			{
 				server, err := http.Server(
 					http.Logger(logger),
-					http.Namespace(namespace),
+					http.Namespace(httpNamespace),
 					http.Context(ctx),
 					http.Config(cfg),
 					http.Metrics(metrics),
@@ -168,7 +169,7 @@ func Server(cfg *config.Config) cli.Command {
 			{
 				server, err := grpc.Server(
 					grpc.Logger(logger),
-					grpc.Namespace(namespace),
+					grpc.Namespace(grpcNamespace),
 					grpc.Context(ctx),
 					grpc.Config(cfg),
 					grpc.Metrics(metrics),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,13 +42,14 @@ type Asset struct {
 
 // Config combines all available configuration parts.
 type Config struct {
-	File    string
-	Log     Log
-	Debug   Debug
-	HTTP    HTTP
-	GRPC    GRPC
-	Tracing Tracing
-	Asset   Asset
+	File      string
+	Namespace string
+	Log       Log
+	Debug     Debug
+	HTTP      HTTP
+	GRPC      GRPC
+	Tracing   Tracing
+	Asset     Asset
 }
 
 // New initializes a new configuration with or without defaults.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,13 +17,15 @@ type Debug struct {
 
 // HTTP defines the available http configuration.
 type HTTP struct {
-	Addr string
-	Root string
+	Addr      string
+	Namespace string
+	Root      string
 }
 
 // GRPC defines the available grpc configuration.
 type GRPC struct {
-	Addr string
+	Addr      string
+	Namespace string
 }
 
 // Tracing defines the available tracing configuration.
@@ -42,14 +44,13 @@ type Asset struct {
 
 // Config combines all available configuration parts.
 type Config struct {
-	File      string
-	Namespace string
-	Log       Log
-	Debug     Debug
-	HTTP      HTTP
-	GRPC      GRPC
-	Tracing   Tracing
-	Asset     Asset
+	File    string
+	Log     Log
+	Debug   Debug
+	HTTP    HTTP
+	GRPC    GRPC
+	Tracing Tracing
+	Asset   Asset
 }
 
 // New initializes a new configuration with or without defaults.

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -144,9 +144,9 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "namespace",
 			Value:       "com.owncloud",
-			Usage:       "",
+			Usage:       "Set the base namespace for both web and api gateway",
 			EnvVar:      "HELLO_NAMESPACE",
-			Destination: &cfg.HTTP.Namespace,
+			Destination: &cfg.Namespace,
 		},
 	}
 }

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -141,5 +141,12 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVar:      "HELLO_ASSET_PATH",
 			Destination: &cfg.Asset.Path,
 		},
+		&cli.StringFlag{
+			Name:        "namespace",
+			Value:       "com.owncloud",
+			Usage:       "",
+			EnvVar:      "HELLO_NAMESPACE",
+			Destination: &cfg.HTTP.Namespace,
+		},
 	}
 }

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -142,11 +142,18 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.Asset.Path,
 		},
 		&cli.StringFlag{
-			Name:        "namespace",
+			Name:        "http-namespace",
 			Value:       "com.owncloud",
-			Usage:       "Set the base namespace for both web and api gateway",
-			EnvVar:      "HELLO_NAMESPACE",
-			Destination: &cfg.Namespace,
+			Usage:       "Set the base namespace for the http namespace",
+			EnvVar:      "HELLO_HTTP_NAMESPACE",
+			Destination: &cfg.HTTP.Namespace,
+		},
+		&cli.StringFlag{
+			Name:        "grpc-namespace",
+			Value:       "com.owncloud",
+			Usage:       "Set the base namespace for the grpc namespace",
+			EnvVar:      "HELLO_GRPC_NAMESPACE",
+			Destination: &cfg.GRPC.Namespace,
 		},
 	}
 }

--- a/pkg/server/grpc/option.go
+++ b/pkg/server/grpc/option.go
@@ -14,11 +14,12 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
-	Logger  log.Logger
-	Context context.Context
-	Config  *config.Config
-	Metrics *metrics.Metrics
-	Flags   []cli.Flag
+	Logger    log.Logger
+	Context   context.Context
+	Config    *config.Config
+	Metrics   *metrics.Metrics
+	Flags     []cli.Flag
+	Namespace string
 }
 
 // newOptions initializes the available default options.
@@ -64,5 +65,12 @@ func Metrics(val *metrics.Metrics) Option {
 func Flags(val []cli.Flag) Option {
 	return func(o *Options) {
 		o.Flags = append(o.Flags, val...)
+	}
+}
+
+// Namespace provides a function to set the namespace option.
+func Namespace(val string) Option {
+	return func(o *Options) {
+		o.Namespace = val
 	}
 }

--- a/pkg/server/grpc/server.go
+++ b/pkg/server/grpc/server.go
@@ -13,8 +13,8 @@ func Server(opts ...Option) (grpc.Service, error) {
 
 	service := grpc.NewService(
 		grpc.Logger(options.Logger),
-		grpc.Namespace("com.owncloud.api"),
-		grpc.Name("hello"),
+		grpc.Namespace(options.Namespace),
+		grpc.Name("api.hello"),
 		grpc.Version(version.String),
 		grpc.Address(options.Config.GRPC.Addr),
 		grpc.Context(options.Context),

--- a/pkg/server/grpc/server.go
+++ b/pkg/server/grpc/server.go
@@ -13,7 +13,7 @@ func Server(opts ...Option) (grpc.Service, error) {
 
 	service := grpc.NewService(
 		grpc.Logger(options.Logger),
-		grpc.Namespace("go.micro.api"),
+		grpc.Namespace("com.owncloud.api"),
 		grpc.Name("hello"),
 		grpc.Version(version.String),
 		grpc.Address(options.Config.GRPC.Addr),

--- a/pkg/server/http/option.go
+++ b/pkg/server/http/option.go
@@ -14,11 +14,12 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
-	Logger  log.Logger
-	Context context.Context
-	Config  *config.Config
-	Metrics *metrics.Metrics
-	Flags   []cli.Flag
+	Logger    log.Logger
+	Context   context.Context
+	Config    *config.Config
+	Metrics   *metrics.Metrics
+	Flags     []cli.Flag
+	Namespace string
 }
 
 // newOptions initializes the available default options.
@@ -64,5 +65,12 @@ func Metrics(val *metrics.Metrics) Option {
 func Flags(val []cli.Flag) Option {
 	return func(o *Options) {
 		o.Flags = append(o.Flags, val...)
+	}
+}
+
+// Namespace provides a function to set the namespace option.
+func Namespace(val string) Option {
+	return func(o *Options) {
+		o.Namespace = val
 	}
 }

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -16,8 +16,8 @@ func Server(opts ...Option) (http.Service, error) {
 
 	service := http.NewService(
 		http.Logger(options.Logger),
-		http.Namespace("com.owncloud.web"),
-		http.Name("hello"),
+		http.Namespace(options.Namespace),
+		http.Name("web.hello"),
 		http.Version(version.String),
 		http.Address(options.Config.HTTP.Addr),
 		http.Context(options.Context),

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -16,7 +16,7 @@ func Server(opts ...Option) (http.Service, error) {
 
 	service := http.NewService(
 		http.Logger(options.Logger),
-		http.Namespace("go.micro.web"),
+		http.Namespace("com.owncloud.web"),
 		http.Name("hello"),
 		http.Version(version.String),
 		http.Address(options.Config.HTTP.Addr),


### PR DESCRIPTION
Small POC. Will probably break some other versions because it is hardcoded, but we're steering in this direction.

- Either make the extension's namespace settable
- Or enforce a default namespace

cc @tboerger 

After a short discussion, 2 flags are being added to the `ocis-hello` command:

![image](https://user-images.githubusercontent.com/6905948/71082772-f73a7780-2191-11ea-94d5-542f1b47c7d7.png)