### PR TITLE
Automatically create a prerelase if the version tag has a suffix

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -400,6 +400,7 @@ def binary(ctx, name):
           'title': ctx.build.ref.replace("refs/tags/v", ""),
           'note': 'dist/CHANGELOG.md',
           'overwrite': True,
+          'prerelease': len(ctx.build.ref.split("-")) > 1,
         },
         'when': {
           'ref': [


### PR DESCRIPTION
# Enhancement to the gitrelease plugin settings
- React on suffixes in the tag and make it a pre release
