### PR TITLE
Project structure consistency

### DIFF
--- a/changelog/unreleased/refactoring.md
+++ b/changelog/unreleased/refactoring.md
@@ -1,0 +1,5 @@
+Enhancement: Streamline project structure
+
+We have aligned the project structure of ocis-hello with other repositories and improved error logging.
+
+https://github.com/owncloud/ocis-hello/pull/79

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "rollup -c",
     "watch": "rollup -c -w",
     "test": "echo 'Not implemented'",
-    "hello": "node node_modules/swagger-vue-generator/bin/generate-api.js --package-version v0 --source pkg/proto/v0/hello.swagger.json --moduleName hello --destination ui/client/hello/index.js",
+    "generate-api": "node node_modules/swagger-vue-generator/bin/generate-api.js --package-version v0 --source pkg/proto/v0/hello.swagger.json --moduleName hello --destination ui/client/hello/index.js",
     "acceptance-tests": "cucumber-js --require-module @babel/register --require-module @babel/polyfill --require ${TEST_INFRA_DIRECTORY}/acceptance/setup.js --require ui/tests/acceptance/stepDefinitions --require ${TEST_INFRA_DIRECTORY}/acceptance/stepDefinitions --format node_modules/cucumber-pretty -t \"${TEST_TAGS:-not @skip and not @skipOnOC10}\""
   },
   "devDependencies": {

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -32,45 +32,7 @@ func Execute() error {
 		Flags: flagset.RootWithConfig(cfg),
 
 		Before: func(c *cli.Context) error {
-			logger := NewLogger(cfg)
-
-			viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-			viper.SetEnvPrefix("HELLO")
-			viper.AutomaticEnv()
-
-			if c.IsSet("config-file") {
-				viper.SetConfigFile(c.String("config-file"))
-			} else {
-				viper.SetConfigName("hello")
-
-				viper.AddConfigPath("/etc/ocis")
-				viper.AddConfigPath("$HOME/.ocis")
-				viper.AddConfigPath("./config")
-			}
-
-			if err := viper.ReadInConfig(); err != nil {
-				switch err.(type) {
-				case viper.ConfigFileNotFoundError:
-					logger.Info().
-						Msg("Continue without config")
-				case viper.UnsupportedConfigError:
-					logger.Fatal().
-						Err(err).
-						Msg("Unsupported config type")
-				default:
-					logger.Fatal().
-						Err(err).
-						Msg("Failed to read config")
-				}
-			}
-
-			if err := viper.Unmarshal(&cfg); err != nil {
-				logger.Fatal().
-					Err(err).
-					Msg("Failed to parse config")
-			}
-
-			return nil
+			return ParseConfig(c, cfg)
 		},
 
 		Commands: []*cli.Command{
@@ -100,4 +62,47 @@ func NewLogger(cfg *config.Config) log.Logger {
 		log.Pretty(cfg.Log.Pretty),
 		log.Color(cfg.Log.Color),
 	)
+}
+
+// ParseConfig loads settings configuration from Viper known paths.
+func ParseConfig(c *cli.Context, cfg *config.Config) error {
+	logger := NewLogger(cfg)
+
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvPrefix("HELLO")
+	viper.AutomaticEnv()
+
+	if c.IsSet("config-file") {
+		viper.SetConfigFile(c.String("config-file"))
+	} else {
+		viper.SetConfigName("hello")
+
+		viper.AddConfigPath("/etc/ocis")
+		viper.AddConfigPath("$HOME/.ocis")
+		viper.AddConfigPath("./config")
+	}
+
+	if err := viper.ReadInConfig(); err != nil {
+		switch err.(type) {
+		case viper.ConfigFileNotFoundError:
+			logger.Info().
+				Msg("Continue without config")
+		case viper.UnsupportedConfigError:
+			logger.Fatal().
+				Err(err).
+				Msg("Unsupported config type")
+		default:
+			logger.Fatal().
+				Err(err).
+				Msg("Failed to read config")
+		}
+	}
+
+	if err := viper.Unmarshal(&cfg); err != nil {
+		logger.Fatal().
+			Err(err).
+			Msg("Failed to parse config")
+	}
+
+	return nil
 }

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -130,7 +130,7 @@ func Server(cfg *config.Config) *cli.Command {
 			var (
 				gr          = run.Group{}
 				ctx, cancel = context.WithCancel(context.Background())
-				mtrcs       = metrics.New()
+				mtrcs       = metrics.New(metrics.Logger(logger))
 			)
 
 			defer cancel()

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -183,6 +183,7 @@ func Server(cfg *config.Config) *cli.Command {
 			{
 				server, err := debug.Server(
 					debug.Logger(logger),
+					debug.Name("hello"),
 					debug.Context(ctx),
 					debug.Config(cfg),
 				)

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -114,6 +114,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.Debug.Zpages,
 		},
 		&cli.StringFlag{
+			Name:        "http-namespace",
+			Value:       "com.owncloud.web",
+			Usage:       "Set the base namespace for the http namespace",
+			EnvVars:     []string{"HELLO_HTTP_NAMESPACE"},
+			Destination: &cfg.HTTP.Namespace,
+		},
+		&cli.StringFlag{
 			Name:        "http-addr",
 			Value:       "0.0.0.0:9105",
 			Usage:       "Address to bind http server",
@@ -128,6 +135,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.HTTP.Root,
 		},
 		&cli.StringFlag{
+			Name:        "grpc-namespace",
+			Value:       "com.owncloud.api",
+			Usage:       "Set the base namespace for the grpc namespace",
+			EnvVars:     []string{"HELLO_GRPC_NAMESPACE"},
+			Destination: &cfg.GRPC.Namespace,
+		},
+		&cli.StringFlag{
 			Name:        "grpc-addr",
 			Value:       "0.0.0.0:9106",
 			Usage:       "Address to bind grpc server",
@@ -140,20 +154,6 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Usage:       "Path to custom assets",
 			EnvVars:     []string{"HELLO_ASSET_PATH"},
 			Destination: &cfg.Asset.Path,
-		},
-		&cli.StringFlag{
-			Name:        "http-namespace",
-			Value:       "com.owncloud",
-			Usage:       "Set the base namespace for the http namespace",
-			EnvVars:     []string{"HELLO_HTTP_NAMESPACE"},
-			Destination: &cfg.HTTP.Namespace,
-		},
-		&cli.StringFlag{
-			Name:        "grpc-namespace",
-			Value:       "com.owncloud",
-			Usage:       "Set the base namespace for the grpc namespace",
-			EnvVars:     []string{"HELLO_GRPC_NAMESPACE"},
-			Destination: &cfg.GRPC.Namespace,
 		},
 		&cli.StringFlag{
 			Name:        "jwt-secret",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,7 +20,9 @@ type Metrics struct {
 }
 
 // New initializes the available metrics.
-func New() *Metrics {
+func New(opts ...Option) *Metrics {
+	options := newOptions(opts...)
+
 	m := &Metrics{
 		Counter: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: Namespace,
@@ -42,17 +44,26 @@ func New() *Metrics {
 		}, []string{}),
 	}
 
-	prometheus.Register(
-		m.Counter,
-	)
+	if err := prometheus.Register(m.Counter); err != nil {
+		options.Logger.Error().
+			Err(err).
+			Str("metric", "counter").
+			Msg("Failed to register prometheus metric")
+	}
 
-	prometheus.Register(
-		m.Latency,
-	)
+	if err := prometheus.Register(m.Latency); err != nil {
+		options.Logger.Error().
+			Err(err).
+			Str("metric", "latency").
+			Msg("Failed to register prometheus metric")
+	}
 
-	prometheus.Register(
-		m.Duration,
-	)
+	if  err := prometheus.Register(m.Duration); err != nil {
+		options.Logger.Error().
+			Err(err).
+			Str("metric", "duration").
+			Msg("Failed to register prometheus metric")
+	}
 
 	return m
 }

--- a/pkg/metrics/option.go
+++ b/pkg/metrics/option.go
@@ -1,0 +1,31 @@
+package metrics
+
+import (
+	"github.com/owncloud/ocis-pkg/v2/log"
+)
+
+// Option defines a single option function.
+type Option func(o *Options)
+
+// Options defines the available options for this package.
+type Options struct {
+	Logger  log.Logger
+}
+
+// newOptions initializes the available default options.
+func newOptions(opts ...Option) Options {
+	opt := Options{}
+
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	return opt
+}
+
+// Logger provides a function to set the logger option.
+func Logger(val log.Logger) Option {
+	return func(o *Options) {
+		o.Logger = val
+	}
+}

--- a/pkg/server/debug/option.go
+++ b/pkg/server/debug/option.go
@@ -12,6 +12,7 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
+	Name    string
 	Logger  log.Logger
 	Context context.Context
 	Config  *config.Config
@@ -26,6 +27,13 @@ func newOptions(opts ...Option) Options {
 	}
 
 	return opt
+}
+
+// Name provides a function to set the name option.
+func Name(val string) Option {
+	return func(o *Options) {
+		o.Name = val
+	}
 }
 
 // Logger provides a function to set the logger option.

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/owncloud/ocis-hello/pkg/config"
 	"github.com/owncloud/ocis-hello/pkg/version"
+	"github.com/owncloud/ocis-pkg/v2/log"
 	"github.com/owncloud/ocis-pkg/v2/service/debug"
 )
 
@@ -15,37 +15,47 @@ func Server(opts ...Option) (*http.Server, error) {
 
 	return debug.NewService(
 		debug.Logger(options.Logger),
-		debug.Name("hello"),
+		debug.Name(options.Name),
 		debug.Version(version.String),
 		debug.Address(options.Config.Debug.Addr),
 		debug.Token(options.Config.Debug.Token),
 		debug.Pprof(options.Config.Debug.Pprof),
 		debug.Zpages(options.Config.Debug.Zpages),
-		debug.Health(health(options.Config)),
-		debug.Ready(ready(options.Config)),
+		debug.Health(health(options.Logger)),
+		debug.Ready(ready(options.Logger)),
 	), nil
 }
 
 // health implements the health check.
-func health(cfg *config.Config) func(http.ResponseWriter, *http.Request) {
+func health(logger log.Logger) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 
 		// TODO(tboerger): check if services are up and running
 
-		io.WriteString(w, http.StatusText(http.StatusOK))
+		if _, err := io.WriteString(w, http.StatusText(http.StatusOK)); err != nil {
+			logger.Error().
+				Err(err).
+				Str("request", "health").
+				Msg("Failed to write response")
+		}
 	}
 }
 
 // ready implements the ready check.
-func ready(cfg *config.Config) func(http.ResponseWriter, *http.Request) {
+func ready(logger log.Logger) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 
 		// TODO(tboerger): check if services are up and running
 
-		io.WriteString(w, http.StatusText(http.StatusOK))
+		if _, err := io.WriteString(w, http.StatusText(http.StatusOK)); err != nil {
+			logger.Error().
+				Err(err).
+				Str("request", "ready").
+				Msg("Failed to write response")
+		}
 	}
 }

--- a/pkg/server/grpc/option.go
+++ b/pkg/server/grpc/option.go
@@ -14,12 +14,12 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
-	Logger    log.Logger
-	Context   context.Context
-	Config    *config.Config
-	Metrics   *metrics.Metrics
-	Flags     []cli.Flag
-	Namespace string
+	Name    string
+	Logger  log.Logger
+	Context context.Context
+	Config  *config.Config
+	Metrics *metrics.Metrics
+	Flags   []cli.Flag
 }
 
 // newOptions initializes the available default options.
@@ -31,6 +31,13 @@ func newOptions(opts ...Option) Options {
 	}
 
 	return opt
+}
+
+// Name provides a function to set the name option.
+func Name(val string) Option {
+	return func(o *Options) {
+		o.Name = val
+	}
 }
 
 // Logger provides a function to set the logger option.
@@ -65,12 +72,5 @@ func Metrics(val *metrics.Metrics) Option {
 func Flags(val []cli.Flag) Option {
 	return func(o *Options) {
 		o.Flags = append(o.Flags, val...)
-	}
-}
-
-// Namespace provides a function to set the namespace option.
-func Namespace(val string) Option {
-	return func(o *Options) {
-		o.Namespace = val
 	}
 }

--- a/pkg/server/grpc/server.go
+++ b/pkg/server/grpc/server.go
@@ -8,31 +8,26 @@ import (
 )
 
 // Server initializes the grpc service and server.
-func Server(opts ...Option) (grpc.Service, error) {
+func Server(opts ...Option) grpc.Service {
 	options := newOptions(opts...)
 
 	service := grpc.NewService(
 		grpc.Logger(options.Logger),
-		grpc.Namespace(options.Namespace),
-		grpc.Name("api.hello"),
+		grpc.Name(options.Name),
 		grpc.Version(version.String),
 		grpc.Address(options.Config.GRPC.Addr),
+		grpc.Namespace(options.Config.GRPC.Namespace),
 		grpc.Context(options.Context),
 		grpc.Flags(options.Flags...),
 	)
 
-	var hello proto.HelloHandler
-	{
-		hello = svc.NewService()
-		hello = svc.NewInstrument(hello, options.Metrics)
-		hello = svc.NewLogging(hello, options.Logger)
+	handler := svc.NewService()
+	handler = svc.NewInstrument(handler, options.Metrics)
+	handler = svc.NewLogging(handler, options.Logger)
+	if err := proto.RegisterHelloHandler(service.Server(), handler); err != nil {
+		options.Logger.Fatal().Err(err).Msg("could not register Hello service handler")
 	}
 
-	proto.RegisterHelloHandler(
-		service.Server(),
-		hello,
-	)
-
 	service.Init()
-	return service, nil
+	return service
 }

--- a/pkg/server/http/option.go
+++ b/pkg/server/http/option.go
@@ -14,12 +14,12 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
+	Name    string
 	Logger    log.Logger
 	Context   context.Context
 	Config    *config.Config
 	Metrics   *metrics.Metrics
 	Flags     []cli.Flag
-	Namespace string
 }
 
 // newOptions initializes the available default options.
@@ -31,6 +31,13 @@ func newOptions(opts ...Option) Options {
 	}
 
 	return opt
+}
+
+// Name provides a name for the service.
+func Name(val string) Option {
+	return func(o *Options) {
+		o.Name = val
+	}
 }
 
 // Logger provides a function to set the logger option.
@@ -65,12 +72,5 @@ func Metrics(val *metrics.Metrics) Option {
 func Flags(val []cli.Flag) Option {
 	return func(o *Options) {
 		o.Flags = append(o.Flags, val...)
-	}
-}
-
-// Namespace provides a function to set the namespace option.
-func Namespace(val string) Option {
-	return func(o *Options) {
-		o.Namespace = val
 	}
 }

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,5 +1,5 @@
 import 'regenerator-runtime/runtime'
-import HelloApp from './components/HelloApp.vue'
+import App from './components/App.vue'
 import store from './store'
 
 const appInfo = {
@@ -18,7 +18,7 @@ const routes = [
     name: 'hello',
     path: '/',
     components: {
-      app: HelloApp
+      app: App
     }
   }
 ]

--- a/ui/components/App.vue
+++ b/ui/components/App.vue
@@ -18,7 +18,7 @@
 
 <script>
 export default {
-  name: 'HelloApp',
+  name: 'App',
   data: function () {
     return {
       name: 'World'


### PR DESCRIPTION
As I'm writing a tutorial on how to build and serve a web-ui from within an ocis-extension, based on ocis-hello and copy-paste instructions, I wanted to streamline ocis-hello and align it with other extensions a little bit. Also, where possible, not name stuff `hello` but give it sensible names. E.g. the run script for generating a javascript api client should not be named `hello`, but something like `generate-api` (for clarity and for reduced search-and-replace effort on copies).