### PR TITLE
rename protoc-gen-swagger to protoc-gen-openapiv2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,8 @@ $(GOPATH)/bin/protoc-gen-micro:
 $(GOPATH)/bin/protoc-gen-microweb:
 	GO111MODULE=off go get -v github.com/webhippie/protoc-gen-microweb
 
-$(GOPATH)/bin/protoc-gen-swagger:
-	GO111MODULE=off go get -v github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
+$(GOPATH)/bin/protoc-gen-openapiv2:
+	GO111MODULE=off go get -v github.com/grpc-ecosystem/grpc-gateway/protoc-gen-openapiv2
 
 pkg/proto/v0/hello.pb.go: pkg/proto/v0/hello.proto
 	protoc \
@@ -197,4 +197,4 @@ pkg/proto/v0/hello.swagger.json: pkg/proto/v0/hello.proto
 		--swagger_out=logtostderr=true:pkg/proto/v0 hello.proto
 
 .PHONY: protobuf
-protobuf:  $(GOPATH)/bin/protoc-gen-go $(GOPATH)/bin/protoc-gen-micro $(GOPATH)/bin/protoc-gen-microweb $(GOPATH)/bin/protoc-gen-swagger pkg/proto/v0/hello.pb.go pkg/proto/v0/hello.pb.micro.go pkg/proto/v0/hello.pb.web.go pkg/proto/v0/hello.swagger.json
+protobuf:  $(GOPATH)/bin/protoc-gen-go $(GOPATH)/bin/protoc-gen-micro $(GOPATH)/bin/protoc-gen-microweb $(GOPATH)/bin/protoc-gen-openapiv2 pkg/proto/v0/hello.pb.go pkg/proto/v0/hello.pb.micro.go pkg/proto/v0/hello.pb.web.go pkg/proto/v0/hello.swagger.json


### PR DESCRIPTION
Package has been renamed upstream as of release 2.0.0.

Fixes https://github.com/owncloud/ocis-hello/issues/91