### PR TITLE
add collapse section in docs

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -3,6 +3,7 @@ title: Hello
 geekdocRepo: https://github.com/owncloud/ocis-hello
 geekdocEditPath: edit/master/docs
 geekdocFilePath: _index.md
+geekdocCollapseSection: true
 ---
 
 [![GitHub](https://img.shields.io/github/license/owncloud/ocis-hello)](https://github.com/owncloud/ocis-hello/blob/master/LICENSE)


### PR DESCRIPTION
This makes the oCIS Hello Section in the docs collapsable.

See also https://github.com/owncloud/ocis/pull/1046 and https://github.com/owncloud/web/pull/4473.